### PR TITLE
Add a simple workflow to run the metadata export

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -1,0 +1,35 @@
+name: Export metadata
+
+on:
+  workflow_dispatch:
+    inputs:
+      mcversion:
+        type: string
+        description: 'The Minecraft version to export for'
+        required: true
+
+jobs:
+  publish:
+    name: Publish export
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build export
+        run: ./gradlew build -Pblackstone_targets_mc_version=${{ inputs.mcversion }}
+
+      - name: Publish export
+        run: ./gradlew publish -Pblackstone_targets_mc_version=${{ inputs.mcversion }}
+        env:
+          LDTTeamJfrogUsername: ${{ secrets.PUBLISHING_USERNAME }}
+          LDTTeamJfrogPassword: ${{ secrets.PUBLISHING_PASSWORD }}


### PR DESCRIPTION
This workflow doesn't trigger automatically (yet), but it should be good enough for manual use right now.